### PR TITLE
Fix log path

### DIFF
--- a/Setup.ps1
+++ b/Setup.ps1
@@ -12,7 +12,7 @@ function Write-Log
 {
     Param (
         [Parameter(Mandatory = $True, Position = 1)][string]$Message,
-        [string]$LogFile = "C:\provision\log.log"
+        [string]$LogFile = "C:\provisions\log.log"
     )
 
     $LogDir = (split-path $LogFile -parent)


### PR DESCRIPTION
All the messages say `C:\provisions\log.log`, but it actually logs right now to `C:\provision\`